### PR TITLE
Cuda no cuda

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 import torch
-from torch.utils.cpp_extension import CppExtension, CUDAExtension
+from torch.utils.cpp_extension import CppExtension, CUDAExtension, CUDA_HOME
 
 ext_modules = [
     CppExtension('basis_cpu', ['cpu/basis.cpp']),
@@ -8,7 +8,7 @@ ext_modules = [
 ]
 cmdclass = {'build_ext': torch.utils.cpp_extension.BuildExtension}
 
-if torch.cuda.is_available():
+if CUDA_HOME is not None:
     ext_modules += [
         CUDAExtension('basis_cuda',
                       ['cuda/basis.cpp', 'cuda/basis_kernel.cu']),

--- a/torch_spline_conv/conv.py
+++ b/torch_spline_conv/conv.py
@@ -7,7 +7,7 @@ from .utils.degree import degree as node_degree
 
 
 class SplineConv(object):
-    """Applies the spline-based convolution operator :math:`(f \star g)(i) =
+    r"""Applies the spline-based convolution operator :math:`(f \star g)(i) =
     \frac{1}{|\mathcal{N}(i)|} \sum_{l=1}^{M_{in}} \sum_{j \in \mathcal{N}(i)}
     f_l(j) \cdot g_l(u(i, j))` over several node features of an input graph.
     The kernel function :math:`g_l` is defined over the weighted B-spline


### PR DESCRIPTION
Not 100% sure about the warning I fixed. I marked the docstring as raw to avoid the undefined character `\s` in [this line](https://github.com/rusty1s/pytorch_spline_conv/blob/31fc84ffa0ef3064feffb2e01aef94ba6deb6a5f/torch_spline_conv/conv.py#L10).