### PR TITLE
Deprecate `torch-spline-conv` in favor of `pyg-lib`

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,10 +1,7 @@
 name: Linting
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
+# Repository deprecated: automatic triggers disabled, manual runs only.
+on: [workflow_dispatch]
 
 jobs:
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,10 +1,7 @@
 name: "Close stale issues and PRs"
 
-on:
-  schedule:
-    # Every day at 00:00
-    - cron: "0 0 * * *"
-  workflow_dispatch:
+# Repository deprecated: scheduled runs disabled, manual runs only.
+on: [workflow_dispatch]
 
 jobs:
   stale:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,10 +1,7 @@
 name: Testing
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
+# Repository deprecated: automatic triggers disabled, manual runs only.
+on: [workflow_dispatch]
 
 jobs:
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 --------------------------------------------------------------------------------
 
 > [!CAUTION]
-> #### ⚠️ This repository is deprecated in favor of [`pyg-team/pyg-lib`](https://github.com/pyg-team/pyg-lib)
+> #### ⚠️ This repository is deprecated in favor of [`pyg-lib>=0.7.0`](https://github.com/pyg-team/pyg-lib)
 
 --------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 --------------------------------------------------------------------------------
 
 > [!CAUTION]
-> ## ⚠️ This repository is deprecated in favor of [`pyg-team/pyg-lib`](https://github.com/pyg-team/pyg-lib)
+> #### ⚠️ This repository is deprecated in favor of [`pyg-team/pyg-lib`](https://github.com/pyg-team/pyg-lib)
 
 --------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 --------------------------------------------------------------------------------
 
 > [!CAUTION]
-> ## ⚠️ This repository is deprecated in favor of [`pyg-lib`](https://github.com/pyg-team/pyg-lib)
+> ## ⚠️ This repository is deprecated in favor of [`pyg-team/pyg-lib`](https://github.com/pyg-team/pyg-lib)
 
 --------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [coverage-image]: https://codecov.io/gh/rusty1s/pytorch_spline_conv/branch/master/graph/badge.svg
 [coverage-url]: https://codecov.io/github/rusty1s/pytorch_spline_conv?branch=master
 
-# Spline-Based Convolution Operator of SplineCNN
+# [DEPRECATED] Spline-Based Convolution Operator of SplineCNN
 
 [![PyPI Version][pypi-image]][pypi-url]
 [![Testing Status][testing-image]][testing-url]
@@ -16,15 +16,22 @@
 
 --------------------------------------------------------------------------------
 
-> [!WARNING]
-> **This repository is deprecated and no longer actively maintained.**
-> No new wheels will be published. The spline-based convolution operator has
-> moved to [`pyg-lib`](https://github.com/pyg-team/pyg-lib), which is the
-> maintained home going forward — please migrate.
+> [!CAUTION]
+> ## ⚠️ This repository is deprecated in favor of [`pyg-lib`](https://github.com/pyg-team/pyg-lib)
 >
-> Previously published wheels remain available at https://data.pyg.org/whl for
-> existing PyTorch versions, but no wheels will be built for future PyTorch or
-> CUDA releases.
+> **`torch-spline-conv` is no longer maintained.** The spline-based convolution
+> operator now lives in [**`pyg-lib`**](https://github.com/pyg-team/pyg-lib) —
+> please install and use that package instead:
+>
+> ```
+> pip install pyg-lib
+> ```
+>
+> - ❌ No new wheels will be published for future PyTorch or CUDA releases.
+> - 📦 Previously published wheels remain available at https://data.pyg.org/whl
+>   for existing PyTorch versions.
+> - 🐛 Issues and pull requests in this repository will no longer be addressed —
+>   please open them in [`pyg-lib`](https://github.com/pyg-team/pyg-lib) instead.
 
 --------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@
 
 --------------------------------------------------------------------------------
 
+> [!WARNING]
+> **This repository is deprecated and no longer actively maintained.**
+> No new wheels will be published. The spline-based convolution operator has
+> moved to [`pyg-lib`](https://github.com/pyg-team/pyg-lib), which is the
+> maintained home going forward — please migrate.
+>
+> Previously published wheels remain available at https://data.pyg.org/whl for
+> existing PyTorch versions, but no wheels will be built for future PyTorch or
+> CUDA releases.
+
+--------------------------------------------------------------------------------
+
 This is a PyTorch implementation of the spline-based convolution operator of SplineCNN, as described in our paper:
 
 Matthias Fey, Jan Eric Lenssen, Frank Weichert, Heinrich Müller: [SplineCNN: Fast Geometric Deep Learning with Continuous B-Spline Kernels](https://arxiv.org/abs/1711.08920) (CVPR 2018)

--- a/README.md
+++ b/README.md
@@ -21,11 +21,9 @@
 >
 > **`torch-spline-conv` is no longer maintained.** The spline-based convolution
 > operator now lives in [**`pyg-lib`**](https://github.com/pyg-team/pyg-lib) —
-> please install and use that package instead:
->
-> ```
-> pip install pyg-lib
-> ```
+> please migrate to that package. See the
+> [`pyg-lib` README](https://github.com/pyg-team/pyg-lib#readme) for
+> installation and usage instructions.
 >
 > - ❌ No new wheels will be published for future PyTorch or CUDA releases.
 > - 📦 Previously published wheels remain available at https://data.pyg.org/whl

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [coverage-image]: https://codecov.io/gh/rusty1s/pytorch_spline_conv/branch/master/graph/badge.svg
 [coverage-url]: https://codecov.io/github/rusty1s/pytorch_spline_conv?branch=master
 
-# [DEPRECATED] Spline-Based Convolution Operator of SplineCNN
+# Spline-Based Convolution Operator of SplineCNN
 
 [![PyPI Version][pypi-image]][pypi-url]
 [![Testing Status][testing-image]][testing-url]
@@ -18,18 +18,6 @@
 
 > [!CAUTION]
 > ## ⚠️ This repository is deprecated in favor of [`pyg-lib`](https://github.com/pyg-team/pyg-lib)
->
-> **`torch-spline-conv` is no longer maintained.** The spline-based convolution
-> operator now lives in [**`pyg-lib`**](https://github.com/pyg-team/pyg-lib) —
-> please migrate to that package. See the
-> [`pyg-lib` README](https://github.com/pyg-team/pyg-lib#readme) for
-> installation and usage instructions.
->
-> - ❌ No new wheels will be published for future PyTorch or CUDA releases.
-> - 📦 Previously published wheels remain available at https://data.pyg.org/whl
->   for existing PyTorch versions.
-> - 🐛 Issues and pull requests in this repository will no longer be addressed —
->   please open them in [`pyg-lib`](https://github.com/pyg-team/pyg-lib) instead.
 
 --------------------------------------------------------------------------------
 

--- a/torch_spline_conv/__init__.py
+++ b/torch_spline_conv/__init__.py
@@ -8,7 +8,7 @@ __version__ = '1.2.2'
 
 warnings.warn(
     "'torch-spline-conv' is deprecated and no longer maintained. All "
-    "functionality has been migrated to 'pyg-lib' "
+    "functionality has been migrated to 'pyg-lib>=0.7.0' "
     "(https://github.com/pyg-team/pyg-lib).",
     DeprecationWarning,
     stacklevel=2,

--- a/torch_spline_conv/__init__.py
+++ b/torch_spline_conv/__init__.py
@@ -7,10 +7,9 @@ import torch
 __version__ = '1.2.2'
 
 warnings.warn(
-    "'torch-spline-conv' is deprecated and no longer maintained. The "
-    "spline-based convolution operator has moved to 'pyg-lib' "
-    "(https://github.com/pyg-team/pyg-lib); please migrate. No new wheels "
-    "will be published for future PyTorch or CUDA releases.",
+    "'torch-spline-conv' is deprecated and no longer maintained. All "
+    "functionality has been migrated to 'pyg-lib' "
+    "(https://github.com/pyg-team/pyg-lib).",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/torch_spline_conv/__init__.py
+++ b/torch_spline_conv/__init__.py
@@ -1,9 +1,19 @@
 import importlib
 import os.path as osp
+import warnings
 
 import torch
 
 __version__ = '1.2.2'
+
+warnings.warn(
+    "'torch-spline-conv' is deprecated and no longer maintained. The "
+    "spline-based convolution operator has moved to 'pyg-lib' "
+    "(https://github.com/pyg-team/pyg-lib); please migrate. No new wheels "
+    "will be published for future PyTorch or CUDA releases.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 for library in ['_version', '_basis', '_weighting']:
     cuda_spec = importlib.machinery.PathFinder().find_spec(


### PR DESCRIPTION
Adding a warning to `__init__.py` for those trying to build from source.